### PR TITLE
验证码不显示的bug修复

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -17,3 +17,9 @@
 - pom.xml里添加了spring-boot-starter-mail依赖
 - application.properties里添加了邮件发送的配置
 
+2024.11.29
+修复了验证码无法显示的bug，之前无法显示验证码的原因是因为没有在登录失败时正确地控制 showCaptcha，
+从而导致验证码输入框未能显示。在修改后的代码中，通过 model.addAttribute("showCaptcha", true) 
+确保了在错误登录次数超过 3 次时，验证码输入框能够正确显示。
+(改变代码
+- UserController

--- a/src/main/java/org/example/spring1114/controller/UserController.java
+++ b/src/main/java/org/example/spring1114/controller/UserController.java
@@ -59,51 +59,42 @@ public class UserController {
                         HttpSession session,
                         @RequestParam(value = "captcha", required = false) String captchaInput) {
 
-        // 获取登录错误次数
         Integer loginAttempts = (Integer) session.getAttribute("loginAttempts");
         if (loginAttempts == null) {
             loginAttempts = 0; // 初始化为 0
         }
-
         // 获取保存的验证码
         String captcha = (String) session.getAttribute("captcha");
-
         // 如果已经尝试过 3 次错误登录，则要求输入验证码
         if (loginAttempts >= 3) {
-            // 校验验证码
             if (captcha == null || !captcha.equals(captchaInput)) {
                 model.addAttribute("msg", "验证码错误，请重试！");
-                return "login"; // 返回登录页面，验证码错误
+                model.addAttribute("showCaptcha", true); // 确保验证码显示
+                return "login"; // 验证码错误，继续显示验证码
             }
         }
-
         // 登录验证
         if (userService.login(username, password)) {
-            // 登录成功，清除错误次数
             session.removeAttribute("loginAttempts");
             session.removeAttribute("captcha"); // 清除验证码
-            System.out.println("Login Success");
-
             session.setAttribute("username", username);
             return "redirect:/home";
         } else {
-            // 登录失败，增加错误次数
             session.setAttribute("loginAttempts", loginAttempts + 1);
-            System.out.println("Login Failed");
             model.addAttribute("msg", "用户名或密码错误");
 
             // 如果错误次数达到 3 次，显示验证码
             if (loginAttempts + 1 >= 3) {
                 model.addAttribute("showCaptcha", true); // 控制显示验证码
+                String newCaptcha = captchaService.generateCaptchaCode(4); // 生成新验证码
+                session.setAttribute("captcha", newCaptcha); // 保存验证码到 session
             } else {
                 model.addAttribute("showCaptcha", false); // 不显示验证码
             }
+
             return "login";
         }
     }
-
-
-
     @GetMapping("/logout")
     public String logout(HttpSession session, Model model) {
         // 清除会话中的用户信息

--- a/src/main/resources/templates/register.html
+++ b/src/main/resources/templates/register.html
@@ -12,10 +12,8 @@
     <div class="register_container">
         <h1 class="title">重人科留言系统</h1>
         <h3 class="sub_title">注 册</h3>
-
         <!-- 显示错误信息 -->
         <p th:text="${msg}" style="color: red"></p>
-
         <!-- 注册表单 -->
         <form method="post" action="doRegister">
             <div class="from_group">
@@ -26,16 +24,13 @@
                 <span>密  码：</span>
                 <input id="pwd" type="password" name="password" placeholder="请输入密码" required/>
             </div>
-
             <div class="from_group">
                 <span>邮  箱：</span>
                 <input id="email" type="email" name="email" placeholder="请输入邮件" required/>
             </div>
-
             <input class="button" type="submit" value="注　　　册"/>
         </form>
     </div>
 </div>
-
 </body>
 </html>


### PR DESCRIPTION
修复了验证码无法显示的bug，之前无法显示验证码的原因是因为没有在登录失败时正确地控制 showCaptcha，
验证码错误时，程序立即返回 "login"，但是此分支中没有设置 showCaptcha.
从而导致验证码输入框未能显示。在修改后的代码中，
通过 model.addAttribute("showCaptcha", true) 
确保了在错误登录次数超过 3 次时，验证码输入框能够正确显示。